### PR TITLE
typetraits: documentation via executable examples

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,7 +54,6 @@ linters:
     - staticcheck
     - tagliatelle
     - tenv
-    - testableexamples
     - testifylint
     - testpackage
     - thelper

--- a/typetraits/typetraits_test.go
+++ b/typetraits/typetraits_test.go
@@ -1,0 +1,40 @@
+package typetraits_test
+
+import (
+	"artk.dev/typetraits"
+)
+
+func ExampleNoCompare() {
+	type T struct {
+		_ typetraits.NoCompare
+	}
+
+	x := T{}
+	_ = x
+
+	// Uncomment to try:
+	// x == T{} // Error!
+}
+
+func ExampleNoCopy() {
+	type T struct {
+		_ typetraits.NoCopy
+	}
+
+	// Uncomment to try:
+	// T{} := T{}  // Error!
+
+	// This is just here to keep the compiler happy.
+	_ = T{}
+
+	// In general, you want to use an anonymous field to avoid exposing
+	// the dummy methods in typetraits.NoCopy. Otherwise, the below code
+	// becomes possible, which is harmless but confusing.
+	type S struct {
+		typetraits.NoCopy // Embedding instead of anonymous field!
+	}
+
+	z := new(S)
+	z.Lock()         // Generally, this method should not be exposed.
+	defer z.Unlock() // Generally, this method should not be exposed.
+}


### PR DESCRIPTION
This package is inherently untestable, so let's use examples at least.