### PR TITLE
httperror: hide the error of unknown messages

### DIFF
--- a/httperror/status.go
+++ b/httperror/status.go
@@ -9,7 +9,7 @@ import (
 func EncodeKind(kind apperror.Kind) int {
 	switch kind {
 	case apperror.OK:
-		return http.StatusNoContent
+		return http.StatusOK
 	case apperror.ValidationError:
 		return http.StatusBadRequest
 	case apperror.UnauthorizedError:

--- a/httperror/text.go
+++ b/httperror/text.go
@@ -16,12 +16,16 @@ func EncodeToText(w http.ResponseWriter, err error) {
 	kind := apperror.KindOf(err)
 	status := EncodeKind(kind)
 
-	var msg string
-	if err != nil {
-		msg = err.Error()
+	switch kind {
+	case apperror.OK:
+		// The only difference compared to just returning is that
+		// the content-type is set.
+		http.Error(w, "", status)
+	case apperror.UnknownError:
+		http.Error(w, "Internal Server Error", status)
+	default:
+		http.Error(w, err.Error(), status)
 	}
-
-	http.Error(w, msg, status)
 }
 
 // DecodeFromText decodes an error from plain text.


### PR DESCRIPTION
Mitigates the risk of displaying internal implementation details to external parties.

Also changes the status code of OK to 200, which is what the standard library uses.